### PR TITLE
refactor : eslint, prettier 설정 변경

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,17 +3,15 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: ["eslint:recommended", "airbnb", "plugin:prettier/recommended"],
+  extends: ['eslint:recommended', 'airbnb', 'plugin:prettier/recommended'],
   overrides: [],
   parserOptions: {
-    ecmaVersion: "latest",
-    sourceType: "module",
+    ecmaVersion: 'latest',
+    sourceType: 'module',
   },
   rules: {
-    "no-use-before-define": ["error", { functions: false }],
-    "class-methods-use-this": [
-      "error",
-      { exceptMethods: ["shadowStyle", "shadowHTML", "setEvents"] },
-    ],
+    'no-use-before-define': ['error', { functions: false }],
+    'class-methods-use-this': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /.idea
 /package-lock.json
+/dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "embeddedLanguageFormatting": "auto",
-  "tabWidth": 2
+  "tabWidth": 2,
+  "printWidth": 120,
+  "singleQuote": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,60 +1,60 @@
-const path = require("path");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const devMode = process.env.NODE_ENV !== "production";
+const devMode = process.env.NODE_ENV !== 'production';
 
 module.exports = {
-  mode: "development",
+  mode: 'development',
   entry: {
-    index: "/src/index.js",
+    index: '/src/index.js',
   },
-  devtool: "inline-source-map",
+  devtool: 'inline-source-map',
   devServer: {
     static: {
-      directory: path.join(__dirname, "public"),
+      directory: path.join(__dirname, 'public'),
     },
     historyApiFallback: true,
     port: 3000,
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: "./public/index.html",
-      title: "Development",
+      template: './public/index.html',
+      title: 'Development',
     }),
     new MiniCssExtractPlugin({
-      filename: "assets/css/[name].[contenthash:8].css",
-      chunkFilename: "assets/css/[name].[contenthash:8].chunk.css",
+      filename: 'assets/css/[name].[contenthash:8].css',
+      chunkFilename: 'assets/css/[name].[contenthash:8].chunk.css',
     }),
   ],
   output: {
-    filename: "[name].bundle.js",
-    path: path.resolve(__dirname, "dist"),
-    publicPath: "/",
+    filename: '[name].bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
     clean: true,
   },
   module: {
     rules: [
       {
         test: /\.(png|svg|jpg|jpeg|gif)$/i,
-        type: "asset/resource",
+        type: 'asset/resource',
       },
       // style-loader, css-loader 구성
       // Sass 파일 로더 설정
       {
         test: /\.s[ac]ss/i,
         use: [
-          devMode ? "style-loader" : MiniCssExtractPlugin.loader,
+          devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
           // css-loader 소스맵 옵션 활성화
           {
-            loader: "css-loader",
+            loader: 'css-loader',
             options: {
               sourceMap: true,
             },
           },
           // sass-loader 소스맵 옵션 활성화
           {
-            loader: "sass-loader",
+            loader: 'sass-loader',
             options: {
               sourceMap: true,
             },
@@ -66,7 +66,7 @@ module.exports = {
   },
   optimization: {
     splitChunks: {
-      chunks: "all",
+      chunks: 'all',
     },
   },
 };


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
eslint 설정과 prettier 설정을 변경하였습니다.
1. `'class-methods-use-this': 'off'` <br/>class내에서 프로토타입 메서드를 정의할때 this가 없어도 에러를 발생시키지 않도록 하기 위함
2.  `prettier/prettier': ['error', { endOfLine: 'auto' }]` <br/>  push 이후 지속적으로 prettier cr 에러가 발생하여 해당 에러를 무시하기 위함

## 추가 설명
webpack.config.js 는 prettier의 singleQuote 옵션에 의해 발생한 변경사항입니다.
해당 변경사항으로 인해 이후 올라오는 PR에서 포맷팅으로 인해 코드 변경점이 많을 수 있습니다...

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
