### PR TITLE
feat : 저장된 NotePad 읽기 기능 추가

### DIFF
--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -7,12 +7,23 @@ class Router {
     this.routes = route;
   }
 
+  pathToRegexp(path) {
+    return new RegExp(`^${path.replace(/\//g, '\\/').replace(/:\w+/g, '(.+)')}$`);
+  }
+
   render() {
-    const route = this.routes.find((value) => value.path === window.location.pathname.replace(BASE_URL, ''));
+    const route = this.routes.find(
+      (value) => window.location.pathname.replace(BASE_URL, '').match(this.pathToRegexp(value.path)) !== null
+    );
 
     if (!route) {
       this.replaceTo('/');
       return;
+    }
+
+    if (route.path.includes('/:id')) {
+      const id = window.location.pathname.replace(BASE_URL, '').match(/\d+/)[0];
+      route.html = route.html.replace(`${route.tag}`, `${route.tag} id="${id}"`);
     }
 
     document.querySelector('#page').innerHTML = route.html;

--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -1,6 +1,4 @@
-import routes from '../utils/routes';
-
-const BASE_URL = process.env.NODE_ENV === 'development' ? '' : '/js-sandbox';
+import routes, { BASE_URL } from '../utils/routes';
 
 class Router {
   constructor(route) {
@@ -12,21 +10,19 @@ class Router {
   }
 
   render() {
-    const route = this.routes.find(
-      (value) => window.location.pathname.replace(BASE_URL, '').match(this.pathToRegexp(value.path)) !== null
-    );
+    const currentPath = window.location.pathname;
+    const route = this.routes.find((value) => this.pathToRegexp(value.path).test(currentPath));
 
     if (!route) {
       this.replaceTo('/');
       return;
     }
 
-    if (route.path.includes('/:id')) {
-      const id = window.location.pathname.replace(BASE_URL, '').match(/\d+/)[0];
-      route.html = route.html.replace(`${route.tag}`, `${route.tag} id="${id}"`);
-    }
+    document.querySelector('#page').innerHTML = route.html.replace(':id', this.getIdFromPath(currentPath));
+  }
 
-    document.querySelector('#page').innerHTML = route.html;
+  getIdFromPath(path) {
+    return path.match(/\d+/)?.[0];
   }
 
   navigateTo(url) {

--- a/src/index.js
+++ b/src/index.js
@@ -29,4 +29,5 @@ import router from './core/Router';
   customElements.define('my-notepad-header', NotePadHeader);
 })();
 
+window.addEventListener('load', () => router.render());
 window.addEventListener('popstate', () => router.render());

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -4,41 +4,38 @@ import flappyBird from '../../public/flappyBird.png';
 import notepad from '../../public/notepad.png';
 import sandboxDB from '../core/IndexedDB';
 
+const BASE_URL = process.env.NODE_ENV === 'development' ? '' : '/js-sandbox';
+
 const routes = [
   {
-    path: '/',
+    path: `${BASE_URL}/`,
     html: html`<my-home></my-home>`,
     label: 'Home',
     iconSrc: null,
-    tag: 'my-home',
   },
   {
-    path: '/tetris',
+    path: `${BASE_URL}/tetris`,
     html: html`<my-tetris></my-tetris>`,
     label: 'Tetris',
     iconSrc: tetris,
-    tag: 'my-tetris',
   },
   {
-    path: '/flappybird',
+    path: `${BASE_URL}/flappybird`,
     html: html`<my-flappybird></my-flappybird>`,
     label: 'Flappy&nbsp;Bird',
     iconSrc: flappyBird,
-    tag: 'my-flappybird',
   },
   {
-    path: '/notepad',
+    path: `${BASE_URL}/notepad`,
     html: html`<my-notepad></my-notepad>`,
     label: 'Note&nbsp;Pad',
     iconSrc: notepad,
-    tag: 'my-notepad',
   },
   {
-    path: '/notepad/:id',
-    html: html`<my-notepad></my-notepad>`,
+    path: `${BASE_URL}/notepad/:id`,
+    html: html`<my-notepad id=":id"></my-notepad>`,
     label: 'Note&nbsp;Pad',
     iconSrc: null,
-    tag: 'my-notepad',
   },
 ];
 
@@ -57,8 +54,6 @@ const getLocalIcons = async () => {
 
   return [...notepadIcons];
 };
-
-const BASE_URL = process.env.NODE_ENV === 'development' ? '' : '/js-sandbox';
 
 export default routes;
 export { mainIcons, getLocalIcons, BASE_URL };

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -10,30 +10,41 @@ const routes = [
     html: html`<my-home></my-home>`,
     label: 'Home',
     iconSrc: null,
+    tag: 'my-home',
   },
   {
     path: '/tetris',
     html: html`<my-tetris></my-tetris>`,
     label: 'Tetris',
     iconSrc: tetris,
+    tag: 'my-tetris',
   },
   {
     path: '/flappybird',
     html: html`<my-flappybird></my-flappybird>`,
     label: 'Flappy&nbsp;Bird',
     iconSrc: flappyBird,
+    tag: 'my-flappybird',
   },
   {
     path: '/notepad',
     html: html`<my-notepad></my-notepad>`,
     label: 'Note&nbsp;Pad',
     iconSrc: notepad,
+    tag: 'my-notepad',
+  },
+  {
+    path: '/notepad/:id',
+    html: html`<my-notepad></my-notepad>`,
+    label: 'Note&nbsp;Pad',
+    iconSrc: null,
+    tag: 'my-notepad',
   },
 ];
 
 const mainIcons = routes.reduce((prev, router) => {
   const { path, label, iconSrc } = router;
-  if (router.path === '/') return prev;
+  if (!router.iconSrc) return prev;
   return [...prev, { path, label, iconSrc }];
 }, []);
 
@@ -47,5 +58,7 @@ const getLocalIcons = async () => {
   return [...notepadIcons];
 };
 
+const BASE_URL = process.env.NODE_ENV === 'development' ? '' : '/js-sandbox';
+
 export default routes;
-export { mainIcons, getLocalIcons };
+export { mainIcons, getLocalIcons, BASE_URL };

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -5,7 +5,11 @@ import sandboxDB from '../../core/IndexedDB';
 import NotePadIcon from '../../../public/notepad.png';
 
 export default class NotePad extends WebComponent {
-  connectedCallback() {
+  async connectedCallback() {
+    this.data = (await sandboxDB.getData('notepad', Number(this.getAttribute('id')))) ?? {
+      title: '제목없음',
+      content: '',
+    };
     super.connectedCallback();
     this.addEventListener('save', this.handleSave);
     this.addEventListener('localSave', this.handleLocalSave);
@@ -17,9 +21,10 @@ export default class NotePad extends WebComponent {
   }
 
   injectHTML() {
+    const { title, content } = this.data;
     return html`
-      <my-notepad-header></my-notepad-header>
-      <textarea></textarea>
+      <my-notepad-header title=${title}></my-notepad-header>
+      <textarea>${content}</textarea>
     `;
   }
 


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
1. 바탕화면에 저장된 노트패드 클릭시 해당 노트패드 열기

## 추가 설명
notepad-save 브랜치의 커밋이 누적되어 있는데, 아래 커밋만 확인해주시면 될 것 같습니다.
[ce416db](https://github.com/f-lab-edu/js-sandbox/pull/9/commits/ce416db8e260952cac881a31e6a190d959895fc5)

호스팅 주소
[https://f-lab-edu.github.io/js-sandbox/](https://f-lab-edu.github.io/js-sandbox/)

## 스크린샷
![image](https://user-images.githubusercontent.com/108395686/227779253-ab67bc87-c945-436e-8d80-dec927ada3cc.png)
![image](https://user-images.githubusercontent.com/108395686/227779257-8178426e-f2c1-42c7-af9f-fc005438d1a9.png)


## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
