### PR TITLE
feat : NotePad 삭제기능 추가

### DIFF
--- a/src/core/IndexedDB.js
+++ b/src/core/IndexedDB.js
@@ -116,7 +116,7 @@ class IndexedDB {
       const request = this.db.transaction(storeName, 'readwrite').objectStore(storeName).delete(id);
 
       request.onsuccess = () => {
-        resolve(request.result);
+        resolve(true);
       };
 
       request.onerror = (e) => {

--- a/src/core/IndexedDB.js
+++ b/src/core/IndexedDB.js
@@ -37,7 +37,7 @@ class IndexedDB {
           if (this.db.objectStoreNames.contains(store)) {
             this.db.deleteObjectStore(store);
           }
-          this.db.createObjectStore(store, { keyPath: 'id', autoIncrement: true });
+          this.db.createObjectStore(store, { keyPath: 'id' });
         });
       };
     });
@@ -90,7 +90,9 @@ class IndexedDB {
    */
   async upsertData(storeName, data) {
     return new Promise((resolve, reject) => {
-      const request = this.db.transaction(storeName, 'readwrite').objectStore(storeName).put(data);
+      const objectStore = this.db.transaction(storeName, 'readwrite').objectStore(storeName);
+      const modifiedData = { ...data, id: data.id || new Date().getTime() };
+      const request = objectStore.put(modifiedData);
 
       request.onsuccess = () => {
         resolve(request.result);

--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -26,7 +26,8 @@ class Router {
   }
 
   navigateTo(url) {
-    if (url === window.location.pathname.replace(BASE_URL, '')) return;
+    const basedUrl = `${BASE_URL}${url}`;
+    if (basedUrl === window.location.pathname) return;
     window.history.pushState(null, null, BASE_URL + url);
     this.render();
   }

--- a/src/core/Router.js
+++ b/src/core/Router.js
@@ -26,6 +26,7 @@ class Router {
   }
 
   navigateTo(url) {
+    if (url === window.location.pathname.replace(BASE_URL, '')) return;
     window.history.pushState(null, null, BASE_URL + url);
     this.render();
   }

--- a/src/view/Common/Icons.js
+++ b/src/view/Common/Icons.js
@@ -86,7 +86,6 @@ export default class Icons extends WebComponent {
 
   handleIconDelete(e) {
     const { path } = e.detail;
-    const newIcons = this.icons.filter((icon) => icon.path !== path);
-    this.icons = newIcons;
+    this.icons = this.icons.filter((icon) => icon.path !== path);
   }
 }

--- a/src/view/Common/Icons.js
+++ b/src/view/Common/Icons.js
@@ -11,6 +11,7 @@ export default class Icons extends WebComponent {
     this.addEventListener('dblclick', this.handleDoubleClick);
     this.addEventListener('keydown', this.handleKeyDown);
     this.addEventListener('iconChange', this.handleIconChange);
+    this.addEventListener('iconDelete', this.handleIconDelete);
   }
 
   static get observedAttributes() {
@@ -81,5 +82,11 @@ export default class Icons extends WebComponent {
       newIcons[prevIconIndex] = { path, label, iconSrc };
       this.icons = newIcons;
     }
+  }
+
+  handleIconDelete(e) {
+    const { path } = e.detail;
+    const newIcons = this.icons.filter((icon) => icon.path !== path);
+    this.icons = newIcons;
   }
 }

--- a/src/view/NotePad/components/NotePadHeader.js
+++ b/src/view/NotePad/components/NotePadHeader.js
@@ -104,8 +104,10 @@ export default class NotePadHeader extends WebComponent {
   }
 
   closePopup() {
-    const popups = this.querySelectorAll('.popup.show');
-    popups.forEach((popup) => popup.classList.remove('show'));
+    // const popups = this.querySelectorAll('.popup.show');
+    // popups.forEach((popup) => popup.classList.remove('show'));
+    const popup = this.querySelector('.popup.show');
+    popup?.classList.remove('show');
   }
 
   get title() {

--- a/src/view/NotePad/components/NotePadHeader.js
+++ b/src/view/NotePad/components/NotePadHeader.js
@@ -105,4 +105,8 @@ export default class NotePadHeader extends WebComponent {
   get title() {
     return this.getAttribute('title');
   }
+
+  get title() {
+    return this.getAttribute('title');
+  }
 }

--- a/src/view/NotePad/components/NotePadHeader.js
+++ b/src/view/NotePad/components/NotePadHeader.js
@@ -82,7 +82,6 @@ export default class NotePadHeader extends WebComponent {
   }
 
   clickEditButton(editButton, sub) {
-    this.closePopup();
     if (sub) {
       const slotId = Number(sub.dataset.id);
       const { onClick } = slots.find((slot) => slot.id === slotId) || {};
@@ -90,16 +89,23 @@ export default class NotePadHeader extends WebComponent {
         onClick.call(this);
       }
     } else {
-      const popup = editButton.querySelector('.popup');
-      popup.classList.toggle('show');
+      this.togglePopup(editButton);
+    }
+  }
+
+  togglePopup(editButton) {
+    const popup = editButton.querySelector('.popup');
+    if (popup.classList.contains('show')) {
+      popup.classList.remove('show');
+    } else {
+      this.closePopup();
+      popup.classList.add('show');
     }
   }
 
   closePopup() {
-    const popup = this.querySelector('.popup.show');
-    if (popup) {
-      popup.classList.remove('show');
-    }
+    const popups = this.querySelectorAll('.popup.show');
+    popups.forEach((popup) => popup.classList.remove('show'));
   }
 
   get title() {

--- a/src/view/NotePad/const/buttons.js
+++ b/src/view/NotePad/const/buttons.js
@@ -1,16 +1,20 @@
+import router from '../../../core/Router';
+
+const disable = true;
+
 const buttons = [
   {
     id: 'file',
     title: '파일',
     key: 'F',
     slots: [
-      { id: 1, text: '새로 만들기(N)', key: ['Ctrl', 'N'], disable: true },
+      { id: 1, text: '새로 만들기(N)', key: ['Ctrl', 'N'], onClick: handleNewClick },
       { id: 2, text: '내 컴퓨터에 저장(W)', key: ['Ctrl', 'Shift', 'N'], onClick: handleLocalSaveClick },
       { id: 3, text: '저장(S)', key: ['Ctrl', 'S'], onClick: handleSaveClick },
-      { id: 4, text: '삭제(D)', key: ['Ctrl', 'Shift', 'S'], disable: true },
-      { id: 5, text: '페이지 설정(U)...', key: [], disable: true },
-      { id: 6, text: '인쇄(P)...', key: ['Ctrl', 'P'], disable: true },
-      { id: 7, text: '끝내기(X)', key: [], disable: true },
+      { id: 4, text: '삭제(D)', key: ['Ctrl', 'Shift', 'S'], onClick: handleDeleteClick },
+      { id: 5, text: '페이지 설정(U)...', key: [], disable },
+      { id: 6, text: '인쇄(P)...', key: ['Ctrl', 'P'], disable },
+      { id: 7, text: '끝내기(X)', key: [], disable },
     ],
   },
   {
@@ -18,19 +22,19 @@ const buttons = [
     title: '편집',
     key: 'E',
     slots: [
-      { id: 8, text: '실행 취소(U)', key: ['Ctrl', 'Z'], disable: true },
-      { id: 9, text: '잘라내기(T)', key: ['Ctrl', 'X'], disable: true },
-      { id: 10, text: '복사(C)', key: ['Ctrl', 'C'], disable: true },
-      { id: 11, text: '붙여넣기(P)', key: ['Ctrl', 'V'], disable: true },
-      { id: 12, text: '삭제(D)', key: ['Del'], disable: true },
-      { id: 13, text: 'Bing으로 검색(S)...', key: ['Ctrl', 'E'], disable: true },
-      { id: 14, text: '찾기(F)...', key: ['Ctrl', 'F'], disable: true },
-      { id: 15, text: '다음 찾기(N)', key: ['F3'], disable: true },
-      { id: 16, text: '이전 찾기(V)', key: ['Shift', 'F3'], disable: true },
-      { id: 17, text: '바꾸기(R)...', key: ['Ctrl', 'H'], disable: true },
-      { id: 18, text: '이동(G)...', key: ['Ctrl', 'G'], disable: true },
-      { id: 19, text: '모두 선택(A)', key: ['Ctrl', 'A'], disable: true },
-      { id: 20, text: '시간/날짜(D)', key: ['F5'], disable: true },
+      { id: 8, text: '실행 취소(U)', key: ['Ctrl', 'Z'], disable },
+      { id: 9, text: '잘라내기(T)', key: ['Ctrl', 'X'], disable },
+      { id: 10, text: '복사(C)', key: ['Ctrl', 'C'], disable },
+      { id: 11, text: '붙여넣기(P)', key: ['Ctrl', 'V'], disable },
+      { id: 12, text: '삭제(D)', key: ['Del'], disable },
+      { id: 13, text: 'Bing으로 검색(S)...', key: ['Ctrl', 'E'], disable },
+      { id: 14, text: '찾기(F)...', key: ['Ctrl', 'F'], disable },
+      { id: 15, text: '다음 찾기(N)', key: ['F3'], disable },
+      { id: 16, text: '이전 찾기(V)', key: ['Shift', 'F3'], disable },
+      { id: 17, text: '바꾸기(R)...', key: ['Ctrl', 'H'], disable },
+      { id: 18, text: '이동(G)...', key: ['Ctrl', 'G'], disable },
+      { id: 19, text: '모두 선택(A)', key: ['Ctrl', 'A'], disable },
+      { id: 20, text: '시간/날짜(D)', key: ['F5'], disable },
     ],
   },
   {
@@ -38,8 +42,8 @@ const buttons = [
     title: '서식',
     key: 'O',
     slots: [
-      { id: 21, text: '자동 줄 바꿈(W)', key: [], disable: true },
-      { id: 22, text: '글꼴(F)...', key: [], disable: true },
+      { id: 21, text: '자동 줄 바꿈(W)', key: [], disable },
+      { id: 22, text: '글꼴(F)...', key: [], disable },
     ],
   },
   {
@@ -47,9 +51,9 @@ const buttons = [
     title: '보기',
     key: 'V',
     slots: [
-      { id: 23, text: '확대하기(Z)', key: ['Ctrl', '+'], disable: true },
-      { id: 24, text: '축소하기(X)', key: ['Ctrl', '-'], disable: true },
-      { id: 25, text: '상태 표시줄(S)', key: [], disable: true },
+      { id: 23, text: '확대하기(Z)', key: ['Ctrl', '+'], disable },
+      { id: 24, text: '축소하기(X)', key: ['Ctrl', '-'], disable },
+      { id: 25, text: '상태 표시줄(S)', key: [], disable },
     ],
   },
   {
@@ -57,9 +61,9 @@ const buttons = [
     title: '도움말',
     key: 'H',
     slots: [
-      { id: 26, text: '도움말 보기(H)', key: [], disable: true },
-      { id: 27, text: '피드백 보내기(F)', key: [], disable: true },
-      { id: 28, text: '메모장 정보(A)', key: [], disable: true },
+      { id: 26, text: '도움말 보기(H)', key: [], disable },
+      { id: 27, text: '피드백 보내기(F)', key: [], disable },
+      { id: 28, text: '메모장 정보(A)', key: [], disable },
     ],
   },
 ];
@@ -77,4 +81,19 @@ function handleSaveClick() {
 
 function handleLocalSaveClick() {
   this.dispatchEvent(new CustomEvent('localSave', { bubbles: true }));
+}
+
+function handleDeleteClick() {
+  const notepad = this.closest('my-notepad');
+  if (notepad.id === 0) return;
+  this.dispatchEvent(new CustomEvent('delete', { bubbles: true }));
+}
+
+function handleNewClick() {
+  const notepad = this.closest('my-notepad');
+  if (notepad.id === 0) {
+    notepad.querySelector('textarea').value = '';
+    return;
+  }
+  router.navigateTo('/notepad');
 }

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -3,7 +3,6 @@ import { html } from '../../utils/utils';
 import './styles.scss';
 import sandboxDB from '../../core/IndexedDB';
 import NotePadIcon from '../../../public/notepad.png';
-import router from '../../core/Router';
 
 export default class NotePad extends WebComponent {
   async connectedCallback() {

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -13,6 +13,7 @@ export default class NotePad extends WebComponent {
     super.connectedCallback();
     this.addEventListener('save', this.handleSave);
     this.addEventListener('localSave', this.handleLocalSave);
+    this.addEventListener('delete', this.handleDelete);
   }
 
   disconnectedCallback() {
@@ -62,6 +63,28 @@ export default class NotePad extends WebComponent {
       router.navigateTo(path);
     } catch (err) {
       alert('저장에 실패했습니다.');
+    }
+  }
+
+  async handleDelete(e) {
+    try {
+      e.stopPropagation();
+      const confirmResult = window.confirm('정말 삭제하시겠습니까?');
+      if (!confirmResult) return;
+
+      const result = await sandboxDB.deleteData('notepad', this.id);
+      if (!result) return;
+
+      alert('삭제되었습니다.');
+      const iconDeleteEvent = new CustomEvent('iconDelete', {
+        detail: {
+          path: `/notepad/${this.id}`,
+        },
+      });
+      document.querySelector('my-icons').dispatchEvent(iconDeleteEvent);
+      router.replaceTo('/notepad');
+    } catch (err) {
+      alert('삭제에 실패했습니다.');
     }
   }
 

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -72,8 +72,7 @@ export default class NotePad extends WebComponent {
       const confirmResult = window.confirm('정말 삭제하시겠습니까?');
       if (!confirmResult) return;
 
-      const result = await sandboxDB.deleteData('notepad', this.id);
-      if (!result) return;
+      await sandboxDB.deleteData('notepad', this.id);
 
       alert('삭제되었습니다.');
       const iconDeleteEvent = new CustomEvent('iconDelete', {


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
1. `src/core/IndexedDB.js`에서 delete 성공시 `resolve(true)` 반환하도록 수정
2. `src/core/Router.js`에서 이동하려는 `url`이 현재 `path`와 같으면 이동하지 않도록 수정
3. delete 기능 추가
4. `src/view/NotePad/components/NotePadHeader.js`에서 `closePopup` => `closePopup, togglePopup` 메서드로 분리
5. `src/view/NotePad/const/buttons.js`에서 `const disable = true` 설정하여 리팩터링
6. 새로 만들기 기능 구현

## 변경 이유
1. 기존 로직에서 delete 성공시 `request.result = undefined`를 반환하여 `true`로 수정함
2. 같은 url history가 반복해서 누적됨을 방지함
3. 핵심 기능 추가
4. 아래 이미지에서 `파일(F)` 버튼 클릭시 popup이 닫히지 않는 현상 수정 및 함수 역할 나누기
![image](https://user-images.githubusercontent.com/108395686/227918790-e4113564-373b-4679-bc4f-6b30bd9868b3.png)
5. disable을 사용하는 객체에서 `disable : true` 반복 제거
6. 간단한 기능 추가

## 추가 설명
호스팅 URL
[https://f-lab-edu.github.io/js-sandbox/](https://f-lab-edu.github.io/js-sandbox/)

아래 커밋 확인해주시면 됩니다!
[0f7ba33](https://github.com/f-lab-edu/js-sandbox/pull/11/commits/0f7ba33620e1d36ce536af3092da47980337aec3)

만약 도메인에서 기능 작동이 안되는 경우 `개발자도구 => Application => indexedDB => sandboxDB => Delete database` 한번 해주시면 됩니다!

IndexedDB delete 레퍼런스
- [https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/delete](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/delete)

## 스크린샷
![image](https://user-images.githubusercontent.com/108395686/227924148-ffd3773a-296b-4d74-8b40-3b9b6d720e24.png)
![image](https://user-images.githubusercontent.com/108395686/227924172-35d2bc89-36a9-4a08-bb4a-0830d923016d.png)
![image](https://user-images.githubusercontent.com/108395686/227924183-0b8a8250-ba12-4a9b-8b95-68468bd88e55.png)

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
