### PR TITLE
fix : NotePad 덮어쓰기 시 라우팅 안되는 버그 수정

### DIFF
--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -33,7 +33,7 @@ const routes = [
   },
   {
     path: `${BASE_URL}/notepad/:id`,
-    html: html`<my-notepad id=":id"></my-notepad>`,
+    html: html`<my-notepad data-id=":id"></my-notepad>`,
     label: 'Note&nbsp;Pad',
     iconSrc: null,
   },

--- a/src/view/NotePad/components/NotePadHeader.js
+++ b/src/view/NotePad/components/NotePadHeader.js
@@ -14,12 +14,22 @@ export default class NotePadHeader extends WebComponent {
     this.removeEventListener('click', this.handleClick);
   }
 
+  static get observedAttributes() {
+    return ['title'];
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (name === 'title' && oldValue) {
+      this.querySelector('#title').innerText = newValue;
+    }
+  }
+
   injectHTML() {
     return html`
       <header>
         <span>
           <img alt="notepad_icon" src=${NotePadIcon} />
-          ${this.title} - Windows 메모장
+          <span id="title">${this.title}</span> - Windows 메모장
         </span>
         <div class="view_buttons">
           <button class="view_button" id="mini">🗕</button>

--- a/src/view/NotePad/components/NotePadHeader.js
+++ b/src/view/NotePad/components/NotePadHeader.js
@@ -104,14 +104,8 @@ export default class NotePadHeader extends WebComponent {
   }
 
   closePopup() {
-    // const popups = this.querySelectorAll('.popup.show');
-    // popups.forEach((popup) => popup.classList.remove('show'));
     const popup = this.querySelector('.popup.show');
     popup?.classList.remove('show');
-  }
-
-  get title() {
-    return this.getAttribute('title');
   }
 
   get title() {

--- a/src/view/NotePad/const/buttons.js
+++ b/src/view/NotePad/const/buttons.js
@@ -84,15 +84,15 @@ function handleLocalSaveClick() {
 }
 
 function handleDeleteClick() {
-  const notepad = this.closest('my-notepad');
-  if (notepad.id === 0) return;
+  const notepad = document.querySelector('my-notepad');
+  if (!notepad['data-id']) return;
   this.dispatchEvent(new CustomEvent('delete', { bubbles: true }));
 }
 
 function handleNewClick() {
-  const notepad = this.closest('my-notepad');
-  if (notepad.id === 0) {
-    notepad.querySelector('textarea').value = '';
+  const notepad = document.querySelector('my-notepad');
+  if (!notepad['data-id']) {
+    notepad.render();
     return;
   }
   router.navigateTo('/notepad');

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -20,6 +20,7 @@ export default class NotePad extends WebComponent {
   disconnectedCallback() {
     this.removeEventListener('save', this.handleSave);
     this.removeEventListener('localSave', this.handleLocalSave);
+    this.removeEventListener('delete', this.handleDelete);
   }
 
   injectHTML() {
@@ -42,11 +43,11 @@ export default class NotePad extends WebComponent {
   }
 
   async handleSave(e) {
-    try {
-      e.stopPropagation();
-      const notePadData = this.getNotePadData();
-      if (!notePadData) return;
+    e.stopPropagation();
+    const notePadData = this.getNotePadData();
+    if (!notePadData) return;
 
+    try {
       const result = await sandboxDB.upsertData('notepad', notePadData);
 
       const path = `/notepad/${result}`;
@@ -55,15 +56,14 @@ export default class NotePad extends WebComponent {
       const iconChangeEvent = new CustomEvent('iconChange', {
         detail: {
           path,
-          label: notePadData.title.replace(/ /g, '&nbsp;'),
+          label: notePadData,
           iconSrc: NotePadIcon,
         },
       });
       document.querySelector('my-icons').dispatchEvent(iconChangeEvent);
 
       if (this.id === result) {
-        this.data = notePadData;
-        this.render();
+        this.title = notePadData.title.replace(/&nbsp/g, ' ');
       } else {
         router.navigateTo(path);
       }
@@ -119,5 +119,9 @@ export default class NotePad extends WebComponent {
 
   get id() {
     return Number(this.getAttribute('data-id'));
+  }
+
+  set title(title) {
+    this.querySelector('my-notepad-header').setAttribute('title', title);
   }
 }

--- a/src/view/NotePad/index.js
+++ b/src/view/NotePad/index.js
@@ -3,6 +3,7 @@ import { html } from '../../utils/utils';
 import './styles.scss';
 import sandboxDB from '../../core/IndexedDB';
 import NotePadIcon from '../../../public/notepad.png';
+import router from '../../core/Router';
 
 export default class NotePad extends WebComponent {
   async connectedCallback() {
@@ -47,7 +48,6 @@ export default class NotePad extends WebComponent {
       if (!notePadData) return;
 
       const result = await sandboxDB.upsertData('notepad', notePadData);
-      if (!result) return;
 
       const path = `/notepad/${result}`;
 
@@ -60,7 +60,13 @@ export default class NotePad extends WebComponent {
         },
       });
       document.querySelector('my-icons').dispatchEvent(iconChangeEvent);
-      router.navigateTo(path);
+
+      if (this.id === result) {
+        this.data = notePadData;
+        this.render();
+      } else {
+        router.navigateTo(path);
+      }
     } catch (err) {
       alert('저장에 실패했습니다.');
     }
@@ -107,11 +113,11 @@ export default class NotePad extends WebComponent {
     return {
       id: this.id,
       title: title.trim().replace(/ /g, '&nbsp;'),
-      content: content.replace(/ /g, '&nbsp;').replace(/\n/g, '<br>').replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;'),
+      content: content.replace(/ /g, '&nbsp;'),
     };
   }
 
   get id() {
-    return Number(this.getAttribute('id'));
+    return Number(this.getAttribute('data-id'));
   }
 }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] 코드 리펙토링
- [ ] 테스트 코드, 리펙토링 테스트 코드 추가
- [ ] 빌드 업무 수정, 패키지 매니저 수정

## 변경 사항
1. `src/utils/routes.js`에서 id => data-id 수정
2. `src/view/NotePad/components/NotePadHeader.js` 주석 제거
3. `src/view/NotePad/const/buttons.js` closest => querySelector 수정
4. 이미 있는 NotePad 덮어쓰기 시 this.render() 실행

## 변경 이유
1. 기본 제공 Attribute인 id와 곂침
2. 불필요한 주석 제거
3. select 방식 통일
4. 덮어쓰기 시 동일한 id이기 때문에 routing이 안되는 현상 수정

## 추가 설명

## 스크린샷

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] PR 내용만 보고도 이해할 수 있을 정도로 기술되었나요?
- [x] 관련 reference가 있다면 함께 적었나요?
- [x] Reviewer, Label을 붙였나요?
